### PR TITLE
reduce load time, Import torch only when necessary

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,7 +1,6 @@
 import launch
-import torch.cuda as cuda
 # launch is imported in context of webui
 if not launch.is_installed("onnxruntime") and not launch.is_installed("onnxruntime-gpu"):
+    import torch.cuda as cuda
     print("Installing onnxruntime")
     launch.run_pip("install onnxruntime-gpu" if cuda.is_available() else "install onnxruntime")
-


### PR DESCRIPTION
don't import torch in installer 
unless it actually needs to check cuda availability
installer is launched under a different sub process, it takes extra time to import anything
on my PC this reduces load time by about a second
| Current | PR |
|--------|--------|
| ![image](https://github.com/aria1th/sd-webui-nsfw-filter/assets/40751091/84003ed8-c5be-43b7-8df1-ccdcbea17cdf)| ![image](https://github.com/aria1th/sd-webui-nsfw-filter/assets/40751091/e524bf1e-6177-4904-bc1d-91e3e35e8b83)| 

tip: `Startup profile` can be found at webui footer