### PR TITLE
enable censor for Live Preview

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -4,16 +4,32 @@ import modules.scripts as scripts
 import torch
 import numpy as np
 from PIL import Image, ImageFilter
+from modules import shared
+
 
 def censor_nsfw(image: Image.Image) -> Image.Image:
     if is_nsfw(image):
         image = image.filter(ImageFilter.GaussianBlur(20))
     return image
 
+
 def on_callback(params: ImageSaveParams):
     params.image = censor_nsfw(params.image)
-    
-    
+
+
+def close_wrapper(fun):
+    def wrapper(*args, **kwargs):
+        try:
+            original_assign_current_image = getattr(shared.state, 'original_assign_current_image', None)
+            if original_assign_current_image:
+                shared.state.assign_current_image = original_assign_current_image
+                shared.state.original_assign_current_image = None
+        except Exception as e:
+            print(e)
+        return fun(*args, **kwargs)
+    return wrapper
+
+
 class Script(scripts.Script):
     
     def __init__(self):
@@ -28,5 +44,21 @@ class Script(scripts.Script):
     def postprocess_image(self, p, pp, *args):
         pp.image = censor_nsfw(pp.image)
 
+
 on_before_image_saved(on_callback)
 print("NSFW filter installed, this will be applied to all images saved from now on")
+
+
+def assign_current_image_wrapper(original_function):
+    def wrapper_function(*args, **kwargs):
+        try:
+            return original_function(censor_nsfw(args[0]), *args[1:], **kwargs)
+        except Exception as e:
+            print(e)
+        return original_function(*args, **kwargs)
+    return wrapper_function
+
+
+if getattr(shared.state, 'original_assign_current_image_nsfw_filter', None) is None:
+    shared.state.original_assign_current_image_nsfw_filter = shared.state.assign_current_image
+    shared.state.assign_current_image = assign_current_image_wrapper(shared.state.assign_current_image)


### PR DESCRIPTION
as mentioned https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/203#issuecomment-1766646900
enable censor on Live Preview
inject the censor function befor `assign_current_image_wrapper` using a wrapper
the original `assign_current_image_wrapper` is stored in `shared.state.original_assign_current_image_nsfw_filter` if you still need to access it
since you did not provide any configuration options in your extension I took the simple route and inject the code once while the extension is loaded

I've done it slightly differently in my extension but the same concept
this is my nsfw censor extension by the way if you're interested
https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor